### PR TITLE
Mark excluded `darts` tests

### DIFF
--- a/exercises/practice/darts/.meta/tests.toml
+++ b/exercises/practice/darts/.meta/tests.toml
@@ -24,5 +24,33 @@ description = "On the inner circle"
 [1c5ffd9f-ea66-462f-9f06-a1303de5a226]
 description = "Exactly on center"
 
+[b65abce3-a679-4550-8115-4b74bda06088]
+description = "Near the center"
+include = false
+
+[66c29c1d-44f5-40cf-9927-e09a1305b399]
+description = "Just within the inner circle"
+include = false
+
+[d1012f63-c97c-4394-b944-7beb3d0b141a]
+description = "Just outside the inner circle"
+include = false
+
+[ab2b5666-b0b4-49c3-9b27-205e790ed945]
+description = "Just within the middle circle"
+include = false
+
+[70f1424e-d690-4860-8caf-9740a52c0161]
+description = "Just outside the middle circle"
+include = false
+
+[a7dbf8db-419c-4712-8a7f-67602b69b293]
+description = "Just within the outer circle"
+include = false
+
+[e0f39315-9f9a-4546-96e4-a9475b885aa7]
+description = "Just outside the outer circle"
+include = false
+
 [045d7d18-d863-4229-818e-b50828c75d19]
 description = "Asymmetric position between the inner and middle circles"


### PR DESCRIPTION
This lets `configlet` knows that the tests were already excluded when we check for new / updated tests with `configlet sync`