### PR TITLE
Fix for DifferenceOfSquaresTest.bat

### DIFF
--- a/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.bat
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.bat
@@ -52,6 +52,7 @@ REM ---------------------------------------------------
 GOTO :End REM Prevents the code below from being executed
 :Assert
 set "stdout="
+set "filePath=%slug%.bat"
 
 REM Run the program and capture the output then delete the file
 if "%isTestRunner%"=="true" (


### PR DESCRIPTION
For issue reported on https://forum.exercism.org/t/difference-of-squares-test-script-keep-on-showing-failed/20000  Seems like the filePath is never set in the test bat when the runner is false. Simple fix, just add set “filePath=%slug%.bat” to line 55, i.e., in :Assert, tested and working