### PR TITLE
Add a space after `<` redirects, required by cmd in Wine 10

### DIFF
--- a/exercises/practice/acronym/AcronymTest.bat
+++ b/exercises/practice/acronym/AcronymTest.bat
@@ -87,7 +87,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %1 %2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.bat
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbersTest.bat
@@ -88,7 +88,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/clock/ClockTest.bat
+++ b/exercises/practice/clock/ClockTest.bat
@@ -145,7 +145,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/darts/DartsTest.bat
+++ b/exercises/practice/darts/DartsTest.bat
@@ -74,7 +74,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.bat
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquaresTest.bat
@@ -59,7 +59,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/grains/GrainsTest.bat
+++ b/exercises/practice/grains/GrainsTest.bat
@@ -86,7 +86,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/hamming/HammingTest.bat
+++ b/exercises/practice/hamming/HammingTest.bat
@@ -77,7 +77,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/hello-world/HelloWorldTest.bat
+++ b/exercises/practice/hello-world/HelloWorldTest.bat
@@ -44,7 +44,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/leap/LeapTest.bat
+++ b/exercises/practice/leap/LeapTest.bat
@@ -88,7 +88,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/nth-prime/NthPrimeTest.bat
+++ b/exercises/practice/nth-prime/NthPrimeTest.bat
@@ -72,7 +72,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/nucleotide-count/NucleotideCountTest.bat
+++ b/exercises/practice/nucleotide-count/NucleotideCountTest.bat
@@ -65,7 +65,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/raindrops/RaindropsTest.bat
+++ b/exercises/practice/raindrops/RaindropsTest.bat
@@ -131,7 +131,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/reverse-string/ReverseStringTest.bat
+++ b/exercises/practice/reverse-string/ReverseStringTest.bat
@@ -67,7 +67,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/scrabble-score/ScrabbleScoreTest.bat
+++ b/exercises/practice/scrabble-score/ScrabbleScoreTest.bat
@@ -95,7 +95,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/series/SeriesTest.bat
+++ b/exercises/practice/series/SeriesTest.bat
@@ -96,7 +96,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/sieve/SieveTest.bat
+++ b/exercises/practice/sieve/SieveTest.bat
@@ -65,7 +65,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/square-root/SquareRootTest.bat
+++ b/exercises/practice/square-root/SquareRootTest.bat
@@ -70,7 +70,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct

--- a/exercises/practice/two-fer/TwoFerTest.bat
+++ b/exercises/practice/two-fer/TwoFerTest.bat
@@ -62,7 +62,7 @@ if "%isTestRunner%"=="true" (
 )
 set batPath=%~dp0
 CALL %batPath%%filePath% %~1 %~2 %~3 %~4 %~5 %~6 %~7 %~8 %~9 > stdout.bin 2>&1
-set /p stdout=<stdout.bin
+set /p stdout=< stdout.bin
 del stdout.bin
 
 REM Check if the result is correct


### PR DESCRIPTION
I have no idea why, but `cmd` in Wine 9 accepts `set /p var=<file` and `cmd` in Wine 10 chokes on that, requiring a space in `< file`. Same exact `cmd` version. In order to bump the OS version and, by extension, the Wine version, we need to fix the tests here.

See https://github.com/exercism/batch-test-runner/pull/57
